### PR TITLE
Fixed linebreaks and German rhyme

### DIFF
--- a/poem.md
+++ b/poem.md
@@ -2,13 +2,13 @@ Poem
 ====
 
 ### English
-Roses are red
-Violets are blue
-Sugar is sweet
+Roses are red  
+Violets are blue  
+Sugar is sweet  
 And so are you
 
 ### German
-Rosen sind rot
-Veilchen sind blau
-Zucker ist suss
-und du bist suss auch
+Rosen sind rot  
+Veilchen sind blau  
+Zucker ist süß  
+und das bist du au’


### PR DESCRIPTION
@zconnelly Fixes linebreak rendering and German translation.

The issue was, that the Markdown source had proper line breaks, but the rendered version was missing those, as the (Github) Markdown renderer just replaces single linebreaks with spaces. I added double spaces to each line ending to force a line break in the rendering.

Also the German translation had incorrect spelling (`suss` instead of `süß`) and didn’t rhyme (as the English version). I changed the 4th line to make it rhyme with the 2nd (`au’` on `blau`). The issue, however, here is that `au’` is not a proper German word, but a (slangy) abbreviation for `auch` (therefore the `’` for ommiting the `ch`). But it rhymes.

### Testing
For the line breaks: See a rendered preview of the changes here: [0bmxa/roses_are_red/poem.md](https://github.com/0bmxa/roses_are_red/blob/master/poem.md)

For the rhyme: Read the German version out loud.

### Issues / Next steps
As mentioned, the selection of the word `au’` is not perfect. This could be improved on.